### PR TITLE
Resolve and send argv[0] as the full absolute path.

### DIFF
--- a/include/dsnet_definitions.h
+++ b/include/dsnet_definitions.h
@@ -28,6 +28,7 @@
 
 #ifdef _WIN32
 #include <winsock.h>
+#define realpath(N,R) _fullpath((R),(N),PATH_MAX)
 #else
 #include <arpa/inet.h>
 #include <netdb.h>

--- a/include/dsnet_prototypes.h
+++ b/include/dsnet_prototypes.h
@@ -126,6 +126,7 @@ extern char *ds_abs_path(char *buf, int len, char *fname);
 extern DS_DESC *ds_open_comport(char *name, DS_RECV_FUNC *recv_func);
 extern DS_DESC *ds_open_netdev(char *name, DS_RECV_FUNC *recv_func);
 extern int ds_comp_main(char *device, int escape);
+extern char* ds_stpcpy(char* dst, char* src);
 
 extern int ds_errno;
 

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -541,3 +541,12 @@ int ds_comp_main(char *device, int escape)
   return 0;
 }
 
+char* ds_stpcpy(char* dst, char* src) {
+  unsigned size = strlen(src);
+  char *p = dst + size;
+
+  memcpy(dst, src, size);
+  *p = '\0';
+
+  return p;
+}


### PR DESCRIPTION
This is needed to make modern ps2sdk path resolution behave well.